### PR TITLE
Expose layout root element

### DIFF
--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -343,7 +343,7 @@ export class Viewport {
     return indices;
   }
 
-  public getContainerElement(): HTMLElement {
+  public getBookViewElement(): HTMLElement {
     return this.bookView.containerElement();
   }
 

--- a/src/navigator/views/viewport.ts
+++ b/src/navigator/views/viewport.ts
@@ -343,6 +343,10 @@ export class Viewport {
     return indices;
   }
 
+  public getContainerElement(): HTMLElement {
+    return this.bookView.containerElement();
+  }
+
   public getSpineItemView(spineItemIndex: number): SpineItemView | undefined {
     return this.bookView.getSpineItemView(spineItemIndex);
   }


### PR DESCRIPTION
We want to get to the LayoutView "container", for the purposes of adding new styles to that specific element from the outside.

It's `layout-view-root` here:

```html
  <div id="viewport-content" style="...">
    <div id="viewport-clipper" style="...">
      <div id="layout-view-root" style="transform: translateX(0px); ...">
        <div id="spine-item-view-...">...</div>
      </div>
    </div>
  </div>
```

We want to mutate the element to add a CSS `transition` style, for example.

This seems like the least drastic change to the API.
From `Rendition` an instance of `Viewport` is already public:
https://github.com/readium/r2-navigator-web/blob/647885dd5564d4018def87f1b0ff2eed98e728e6/src/navigator/rendition.ts#L22

From `Viewport`, `bookView: LayoutView` is private.. this is fine:
https://github.com/readium/r2-navigator-web/blob/a2a1174db8eaffdbaa07062c4e498edf20aef69c/src/navigator/views/viewport.ts#L16

Because, the element is being accessed by the proposed new getter on `Viewport`, that exposes it from `bookView: LayoutView`:
https://github.com/readium/r2-navigator-web/blob/a2a1174db8eaffdbaa07062c4e498edf20aef69c/src/navigator/views/viewport.ts#L346
